### PR TITLE
Like I said before lots has changed

### DIFF
--- a/git.vimrc
+++ b/git.vimrc
@@ -60,12 +60,7 @@ set autoread                    "reload files if changed externally
 " => Key-bindings *leave right uncommeted,seen as command 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " mapped leader to <'>
-let mapleader="'"
-" move vertically by visual line (don't skip wrapped lines)
-nnoremap k gk
-nnoremap j gj
-noremap <Up> gk
-noremap <Down> gj
+let mapleader = "'"
 " changes cursor to a bar when in insert mode 
 let &t_SI = "\<Esc>]50;CursorShape=1\x7"
 let &t_EI = "\<Esc>]50;CursorShape=0\x7"
@@ -73,11 +68,18 @@ let &t_EI = "\<Esc>]50;CursorShape=0\x7"
 nnoremap : q:i
 nnoremap / q/i
 " => Open terminal inside Vim
-map <Leader>tt :vert term<CR>
+nnoremap <Leader>tt :vert term<CR>
 " quickly open a buffer for scribble
-map <leader>q :e ~/buffer<cr>
+noremap <leader>q :e ~/buffer<cr>
 " close buffer not window
 nnoremap Q :Bclose<CR>
+" buffer tabbing
+noremap <Leader>bb :bnext<CR>
+noremap <Leader>bg :bprev<CR>
+" Underline the current line, based on its length.
+noremap <silent> <leader>ul mmyypVr-<Esc>`m
+" Switch to current dir
+noremap <Leader>scd :cd %:p:h<cr>
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " => Text editing
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
decided to try. Doing by section at a time.
So first up keybinding section
first thing is my mapleader command was in bad formate. Not sure
how this happened. But noticed as I scan up and down.
So just added the proper spacing
second moved the, "move by visual lines" binding down further.
may be getting over written. What I've read suggests that some
commands are better kept closer to the bottom of the list.
I could see this. feel like I'm at that point where any more tweaking
is going to start tromping on one or the other. max bloat...maybe?
next is my recursive mapping. once again what I've read says that I
should use the recursive version all the time on everything. so changed
all of them. at which point any that stopped working proper I would Switch
back. like the buffer tag line bindings won't work with nore prefix
attached. so watch for anything that use to work but now doesn't.
in these hunks I've added buffer bindings. just sort of discovered
buffers knew about them but the whole tab thing really muddies up
the water. drop all the tab stuff and play with buffers instead.
buffers make sense where as tabs seem confusing.